### PR TITLE
Fix prisma generate on vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "vercel-build": "prisma generate && next build",
+    "postinstall": "prisma generate",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
Add `prisma generate` to Vercel build steps to resolve `PrismaClientInitializationError`.

Vercel's dependency caching can prevent `prisma generate` from running, leading to an outdated Prisma Client. This PR adds `postinstall` and `vercel-build` scripts to `package.json` to ensure the Prisma Client is always generated before the Next.js build, fixing the build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-3e71bc3d-3482-49cb-b552-ad617673d9f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3e71bc3d-3482-49cb-b552-ad617673d9f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

